### PR TITLE
Point to Guardian fork of Thrift

### DIFF
--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV THRIFT_VERSION v0.14.0-gu1
+ENV THRIFT_VERSION v0.14.0-gu4
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 		pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/davidfurey/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \


### PR DESCRIPTION
This points to https://github.com/guardian/french-thrift instead of https://github.com/davidfurey/thrift. The Guardian fork contains all the changes that we need that haven't yet been merged into the Apache repo.