### PR TITLE
generate and publish javascript files

### DIFF
--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -9,12 +9,15 @@ npm init -y
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 npx json -I -f package.json -e 'this.types="index.d.ts"'
 
-# generate JavaScript files
+# generate JavaScript files with type declarations
 npm i typescript -g
-npx tsc --init --declaration
+npx tsc --init --declaration --target ES2016
 npx tsc
 
-# use repo tags for version
+# remove TypeScript files
+ls | grep "^[A-Za-z]*.ts" | xargs rm
+
+# use repo tag for version
 git fetch --all
 CURRENT_FULL_VERSION="$(git describe --tags --abbrev=0)"
 

--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -1,14 +1,23 @@
-# generate TypeScript Native Thrift files 
+# generate TypeScript Thrift files
 node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget-typescript ../thrift/native.thrift
 node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget-typescript ../thrift/webview.thrift
 
-# publish TypeScript package to npm
 cd bridget-typescript
+
+# create package.json
 npm init -y
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+npx json -I -f package.json -e 'this.types="index.d.ts"'
 
+# generate JavaScript files
+npm i typescript -g
+npx tsc --init --declaration
+npx tsc
+
+# use repo tags for version
 git fetch --all
 CURRENT_FULL_VERSION="$(git describe --tags --abbrev=0)"
 
+# publish to npm
 npm version ${CURRENT_FULL_VERSION}
 npm publish --access public

--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -1,18 +1,17 @@
 # generate TypeScript Thrift files
-node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget-typescript ../thrift/native.thrift
-node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget-typescript ../thrift/webview.thrift
+node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget ../thrift/native.thrift
+node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget ../thrift/webview.thrift
 
-cd bridget-typescript
+cd bridget
 
 # create package.json
 npm init -y
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-npx json -I -f package.json -e 'this.types="index.d.ts"'
+../node_modules/.bin/json -I -f package.json -e 'this.types="index.d.ts"'
 
 # generate JavaScript files with type declarations
-npm i typescript -g
-npx tsc --init --declaration --target ES2016
-npx tsc
+../node_modules/.bin/tsc --init --declaration --target ES2016
+../node_modules/.bin/tsc
 
 # remove TypeScript files
 ls | grep "^[A-Za-z]*.ts" | xargs rm

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,14 @@
         "fs-extra": "^8.0.1",
         "glob": "^7.1.2",
         "typescript": "3.5.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+          "dev": true
+        }
       }
     },
     "@types/fs-extra": {
@@ -129,6 +137,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "json": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -169,9 +183,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "homepage": "https://github.com/guardian/mobile-apps-thrift#readme",
   "devDependencies": {
     "@creditkarma/thrift-server-core": "^0.15.3",
-    "@creditkarma/thrift-typescript": "^3.7.6"
+    "@creditkarma/thrift-typescript": "^3.7.6",
+    "json": "^9.0.6",
+    "typescript": "^3.8.3"
   },
-  "keywords": []
+  "keywords": [],
+  "dependencies": {}
 }


### PR DESCRIPTION
This generates JavaScript files with TypeScript definitions for the bridget APIs. This should allow the APIs to be used outside of apps-rendering in other webviews such as interactive atoms.


TODO:
- rename `gen-typescrpt` to `gen-javascript-typescript`
