### PR TITLE
remove unused webview thrift file

### DIFF
--- a/.github/actions/generate-native-package/native.sh
+++ b/.github/actions/generate-native-package/native.sh
@@ -24,7 +24,6 @@ if [ "$PLATFORM" == "ios" ]; then
     rm -rf bridget-swift/Sources/Bridget
     mkdir -p bridget-swift/Sources/Bridget
 
-    thrift --gen swift -r -out bridget-swift/Sources/Bridget bridget/thrift/webview.thrift
     thrift --gen swift:async_servers -r -out bridget-swift/Sources/Bridget bridget/thrift/native.thrift
 
     # Commit changes
@@ -37,7 +36,6 @@ if [ "$PLATFORM" == "ios" ]; then
         git push --tags
     fi
 elif [ "$PLATFORM" == "android" ]; then
-    thrift --gen java -r bridget/thrift/webview.thrift
     ls gen-java
 else
     echo "Unrecognised platform. Please specify \"ios\" or \"android\" as the second argument"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ The repo is also responsible for generating and publishing packages to be used b
 ## Thrift definitions
 `native.thrift` are the functions to be implemented by iOS and Android. The webview will be able to call these functions with the specified arguments.
 
-`webview.thrift` are the functions to be implemented by the [Webview](https://github.com/guardian/apps-rendering). iOS and Android will be able to call these functions with the specified arguments.
-
 ## Generated packages
 The Swift and Java packages are generated and published using this [GitHub action](https://github.com/guardian/mobile-apps-thrift/blob/master/.github/actions/generate-native-package/action.yml)
 
@@ -16,7 +14,7 @@ The Swift and Java packages are generated and published using this [GitHub actio
 
 
 ## Adding a new function
-1. Define the function in `native.thrift` if it needs to be implemented in Swift & Kotlin or define the function in `webview.thrift` if it needs to be implemented in the webView
+1. Define the function in `native.thrift` if it needs to be implemented in Swift & Kotlin
 2. Make sure to add a comment above the function to document what it does. It's a good idea to add the version it was available from too (this will be a minor update to the latest tag)
 3. Make a pull request. It would be good to get a review from all teams who would need to implement or call the function. e.g. Android, iOS and apps-rendering
 4. Merging into master will automatically run the GitHub actions to publish packages

--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -1,6 +1,5 @@
 # generate TypeScript Thrift files
 node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget ../thrift/native.thrift
-node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget ../thrift/webview.thrift
 
 cd bridget
 

--- a/thrift/webview.thrift
+++ b/thrift/webview.thrift
@@ -1,4 +1,0 @@
-service Webview {
-	i32 webviewThriftPackage(),
-	void updateFontSize(1:i32 size),
-}


### PR DESCRIPTION
With the new fontSize solution it looks like we no longer need the native to webView communication.