### PR TITLE
Add a better display name for users

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -7,6 +7,8 @@ struct AdSlot {
 
 struct Topic {
     1: required string id;
+    2: required string displayName;
+    3: required string type;
 }
 
 struct Image {


### PR DESCRIPTION
https://github.com/guardian/bridget/issues/37

Would an enum be useful?

```
enum TopicType {
    Content,
    TagContributor,
    TagKeyword,
    TagSeries,
    TagBlog
    FootballTeam,
    FootballMatch
}
```