### PR TITLE
pass article title to native layers

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -54,5 +54,5 @@ service User {
 }
 
 service Gallery {
-    void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex)
+    void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex, 3:string articleTitle)
 }


### PR DESCRIPTION
https://github.com/guardian/bridget/issues/40

iOS and Android both show the title in the gallery viewer, so I think it makes sense to pass this additional information.

Follow up apps-rendering change: https://github.com/guardian/apps-rendering/pull/349