### PR TITLE
add version const

### DIFF
--- a/.github/actions/generate-native-package/native.sh
+++ b/.github/actions/generate-native-package/native.sh
@@ -16,6 +16,10 @@ cd bridget
 CURRENT_VERSION="$(git describe --tags --abbrev=0)"
 cd ../
 
+# Add version const to thrift file
+echo "\n" > bridget/thrift/native.thrift
+echo "const string BRIDGET_VERSION = $CURRENT_VERSION;" > bridget/thrift/native.thrift
+
 # Platform tasks
 if [ "$PLATFORM" == "ios" ]; then
 


### PR DESCRIPTION
I thought we would be able to read package versions in iOS/Android but I can't see a way to do this.

This can be used like:
```
extension SSRItemViewController: Environment {
    func nativeThriftPackageVersion() throws -> string {
        return BRIDGET_VERSION
    }
}
```

That function is currently returning an int, although we might want to change it to a string so we can use semVer?
