### PR TITLE
add targeting param map to AdSlot

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -3,7 +3,7 @@ struct AdSlot {
     2: required i32 y;
     3: optional i32 height;
     4: optional i32 width;
-    5: optional map<string,string> adTargeting;
+    5: optional map<string,string> targetingParams;
 }
 
 struct Topic {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -3,6 +3,7 @@ struct AdSlot {
     2: required i32 y;
     3: optional i32 height;
     4: optional i32 width;
+    5: optional map<string,string> adTargeting;
 }
 
 struct Topic {


### PR DESCRIPTION
https://github.com/guardian/bridget/issues/38

apart from `index` do we need to pass this map of data with every adSlot?
