### PR TITLE
Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 # Built files
 dist
 mobile-apps-thrift-typescript
+bridget

--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -1,5 +1,5 @@
 # generate TypeScript Thrift files
-node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget ../thrift/native.thrift
+node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir bridget --strictUnions ../thrift/native.thrift
 
 cd bridget
 

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -40,6 +40,35 @@ struct VideoSlot {
     4: required i32 duration;
 }
 
+enum MetricKind {
+    FirstPaint = 0;
+    FirstContentfulPaint = 1;
+    Font = 2;
+}
+
+struct MetricFirstPaint {
+    1: required MetricKind kind;
+    2: required double time;
+}
+
+struct MetricFirstContentfulPaint {
+    1: required MetricKind kind;
+    2: required double time;
+}
+
+struct MetricFont {
+    1: required MetricKind kind;
+    2: required double duration;
+    3: optional i32 size;
+    4: optional string name;
+}
+
+union Metric {
+    1: MetricFirstPaint firstPaint;
+    2: MetricFirstContentfulPaint firstContentfulPaint;
+    3: MetricFont font;
+}
+
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -72,4 +101,8 @@ service Gallery {
 service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
     void updateVideos(1:list<VideoSlot> videoSlots)
+}
+
+service Metrics {
+    void sendMetrics(1:list<Metric> metrics)
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -40,32 +40,19 @@ struct VideoSlot {
     4: required i32 duration;
 }
 
-enum MetricKind {
-    FirstPaint = 0;
-    FirstContentfulPaint = 1;
-    Font = 2;
-}
-
-struct MetricFirstPaint {
-    1: required MetricKind kind;
-    2: required double time;
-}
-
-struct MetricFirstContentfulPaint {
-    1: required MetricKind kind;
-    2: required double time;
+struct MetricPaint {
+    1: required double time;
 }
 
 struct MetricFont {
-    1: required MetricKind kind;
-    2: required double duration;
-    3: optional i32 size;
-    4: optional string name;
+    1: required double duration;
+    2: optional i32 size;
+    3: optional string name;
 }
 
 union Metric {
-    1: MetricFirstPaint firstPaint;
-    2: MetricFirstContentfulPaint firstContentfulPaint;
+    1: MetricPaint firstPaint;
+    2: MetricPaint firstContentfulPaint;
     3: MetricFont font;
 }
 


### PR DESCRIPTION
## What does this change?

Added types and a new service for passing metrics to the native layers. Current metrics supported include "paint" events and font information. Relates to the work done on [apps-rendering](https://github.com/guardian/apps-rendering/pull/390).

## How can we measure success?

We can send metrics to the apps.
