### PR TITLE
add height and width to image struct

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -18,8 +18,10 @@ struct Topic {
 
 struct Image {
     1: required string url;
-    2: optional string caption;
-    3: optional string credit;
+    2: required double width;
+    3: required double height;
+    4: optional string caption;
+    5: optional string credit;
 }
 
 struct Epic {


### PR DESCRIPTION
Fix for GLA-2121, where images can be shown in the incorrect ratio in the slideshow/lightbox viewer.

apps-rendering and iOS changes required to implement this update.
