### PR TITLE
apis to use discussion rendering

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -65,13 +65,6 @@ struct CommentResponse {
     4: optional string errorCode;
 }
 
-struct ReportAbuse {
-    1: required i32 commentId;
-    2: required i32 categoryId;
-    3: optional string reason;
-    4: optional string email;
-}
-
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -117,7 +110,6 @@ service Discussion {
     string preview(1:string body),
     CommentResponse comment(1:string shortUrl, 2:string body),
     CommentResponse reply(1:string shortUrl, 2:string body, 3:string parentCommentId),
-    CommentResponse reportAbuse(1:ReportAbuse reportAbuse),
     boolean recommend(1:commentId i32),
     bool isDiscussionEnabled()
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -58,6 +58,13 @@ union Metric {
     3: MetricFont font;
 }
 
+struct UserData {
+    1: required string userId;
+    2: required string displayName;
+    3: optional string avatar;
+    4: optional list<string> badge;
+}
+
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -81,7 +88,8 @@ service Notifications {
 
 service User {
     bool isPremium(),
-    list<string> filterSeenArticles(1:list<string> articleIds)
+    list<string> filterSeenArticles(1:list<string> articleIds),
+    UserData userData()
 }
 
 service Gallery {
@@ -95,4 +103,8 @@ service Videos {
 
 service Metrics {
     void sendMetrics(1:list<Metric> metrics)
+}
+
+service Discussion {
+    map<string, string> authenticationHeaders()
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -110,6 +110,6 @@ service Discussion {
     string preview(1:string body),
     CommentResponse comment(1:string shortUrl, 2:string body),
     CommentResponse reply(1:string shortUrl, 2:string body, 3:string parentCommentId),
-    boolean recommend(1:commentId i32),
+    bool recommend(1:commentId i32),
     bool isDiscussionEnabled()
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -58,13 +58,6 @@ union Metric {
     3: MetricFont font;
 }
 
-struct UserData {
-    1: required string userId;
-    2: required string displayName;
-    3: optional string avatar;
-    4: optional list<string> badge;
-}
-
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -89,7 +82,7 @@ service Notifications {
 service User {
     bool isPremium(),
     list<string> filterSeenArticles(1:list<string> articleIds),
-    UserData userData(),
+    string discussionId(),
     bool doesCcpaApply()
 }
 
@@ -107,6 +100,7 @@ service Metrics {
 }
 
 service Discussion {
-    string getClientName()
-    string getIdentityToken()
+    string getClientName(),
+    string getIdentityToken(),
+    bool isDiscussionEnabled()
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -107,5 +107,6 @@ service Metrics {
 }
 
 service Discussion {
-    map<string, string> authenticationHeaders()
+    string getClientName()
+    string getIdentityToken()
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -58,6 +58,20 @@ union Metric {
     3: MetricFont font;
 }
 
+struct CommentResponse {
+    1: required string status;
+    2: required i32 statusCode;
+    3: required string message;
+    4: optional string errorCode;
+}
+
+struct ReportAbuse {
+    1: required i32 commentId;
+    2: required i32 categoryId;
+    3: optional string reason;
+    4: optional string email;
+}
+
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -100,7 +114,10 @@ service Metrics {
 }
 
 service Discussion {
-    string getClientName(),
-    string getIdentityToken(),
+    string preview(1:string body),
+    CommentResponse comment(1:string shortUrl, 2:string body),
+    CommentResponse reply(1:string shortUrl, 2:string body, 3:string parentCommentId),
+    CommentResponse reportAbuse(1:ReportAbuse reportAbuse),
+    boolean recommend(1:commentId i32),
     bool isDiscussionEnabled()
 }


### PR DESCRIPTION
## What does this change?
- By retrieving the user Id from the native layers, we can make a request to the discussion service for things like name, avatar url and badges.
- Adds callbacks that we can hopefully pass through to disucssion-rendering https://github.com/guardian/discussion-rendering/pull/344