### PR TITLE
Friction screen reason

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -65,6 +65,11 @@ struct CommentResponse {
     4: optional string errorCode;
 }
 
+enum FrictionScreenReason {
+    hideAds = 0,
+    epic = 1
+}
+
 service Environment {
     string nativeThriftPackageVersion()
 }
@@ -75,7 +80,7 @@ service Commercial {
 }
 
 service Acquisitions {
-    void launchFrictionScreen(),
+    void launchFrictionScreen(1: FrictionScreenReason reason),
     MaybeEpic getEpics(),
     void epicSeen()
 }


### PR DESCRIPTION
## Friction screen reason

This PR adds the type `FrictionScreenReason` which is an enum of either values: `hideAds` or `epic`.

The explicit integer values ( ` = 0` and ` = 1`) are not necessary, however it's best to be explicit in these types as order matters in thrift definitions. 