### PR TITLE
Rename friction screen to purchase screen

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -65,7 +65,7 @@ struct CommentResponse {
     4: optional string errorCode;
 }
 
-enum FrictionScreenReason {
+enum PurchaseScreenReason {
     hideAds = 0,
     epic = 1
 }
@@ -80,7 +80,7 @@ service Commercial {
 }
 
 service Acquisitions {
-    void launchFrictionScreen(1: FrictionScreenReason reason),
+    void launchPurchaseScreen(1: PurchaseScreenReason reason),
     MaybeEpic getEpics(),
     void epicSeen()
 }


### PR DESCRIPTION
`launchFrictionScreen` in reality is launching the purchase screen. Renaming this before we go to prod so we're more consistent naming wise.