### PR TITLE
LIVE-1852:  Analytics service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridget",
-  "version": "1.0.0",
+  "version": "1.9.0",
   "description": "Thrift files defining the API between native layers (iOS, Android) and [Webview](https://github.com/guardian/apps-rendering).",
   "main": "index.js",
   "scripts": {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -118,3 +118,7 @@ service Discussion {
     CommentResponse comment(1:string shortUrl, 2:string body),
     CommentResponse reply(1:string shortUrl, 2:string body, 3:i32 parentCommentId)
 }
+
+service Analytics {
+    void sendTargetingParams(1:map<string, string> targetingParams)
+}


### PR DESCRIPTION
## What does this change?
Creates a new Analytics service with a single method to send targeting params. Currently the targeting params exist inside the article `<head />` in an `application/json` script that looks like this:
```html

<script id="targeting-params" type="application/json">
{"ct":"article","co":"rebecca-ratcliffe","url":"/world/2021/apr/06/wanted-lists-published-in-myanmar-as-junta-extends-crackdown","su":"4,5","edition":"uk","tn":"news","p":"app","k":"world,south-and-central-asia,myanmar"}
</script>

```
We can use the new method to send these over.

