### PR TITLE
Add sendArticleHeight to Metrics service

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -110,6 +110,7 @@ service Videos {
 
 service Metrics {
     void sendMetrics(1:list<Metric> metrics)
+    void sendArticleHeight(1:i32 articleHeight)
 }
 
 service Discussion {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This function will give the article layer a way to pass the height of the article to the native layer for the purpose of scroll depth tracking.

Units for `articleHeight` TBC - pixels? dips? 

@JamieB-gu @aoifemcl15 

Related Android PR is here (draft):

https://github.com/guardian/android-news-app/pull/6911