### PR TITLE
Fix README link to NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The repo is also responsible for generating and publishing packages to be used b
 ## Generated packages
 The Swift and Java packages are generated and published using this [GitHub action](https://github.com/guardian/mobile-apps-thrift/blob/main/.github/actions/generate-native-package/action.yml)
 
-- The TypeScript package can be installed from [NPM](https://www.npmjs.com/package/mobile-apps-thrift-typescript)
+- The TypeScript package can be installed from [NPM](https://www.npmjs.com/package/@guardian/bridget)
 - Swift package can be installed with Swift Package Manager from [GitHub](https://github.com/guardian/mobile-apps-thrift-swift)
 
 


### PR DESCRIPTION
## What does this change?

- Fixes link to the generated NPM package `@guardian/bridget`
