### PR TITLE
docs: update link to apps-rendering repo and info about java package publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The repo is also responsible for generating and publishing packages to be used b
 `native.thrift` are the functions to be implemented by iOS and Android. The webview will be able to call these functions with the specified arguments.
 
 ## Generated packages
-The Swift and TypeScript packages are generated and published using this [GitHub action](https://github.com/guardian/mobile-apps-thrift/blob/main/.github/actions/generate-native-package/action.yml)
+The Swift and TypeScript packages are generated and published using this [GitHub action](.github/workflows/generate-packages.yml).
 
 - The TypeScript package can be installed from [NPM](https://www.npmjs.com/package/mobile-apps-thrift-typescript)
 - Swift package can be installed with Swift Package Manager from [GitHub](https://github.com/guardian/mobile-apps-thrift-swift)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bridget
-This repo contains the thrift definitions defining the API between native layers (iOS, Android) and [Webview](https://github.com/guardian/apps-rendering).
+This repo contains the thrift definitions defining the API between native layers (iOS, Android) and [Webview](https://github.com/guardian/dotcom-rendering/tree/main/apps-rendering).
 
 The repo is also responsible for generating and publishing packages to be used by iOS, Android and the Webview.
 
@@ -7,7 +7,7 @@ The repo is also responsible for generating and publishing packages to be used b
 `native.thrift` are the functions to be implemented by iOS and Android. The webview will be able to call these functions with the specified arguments.
 
 ## Generated packages
-The Swift and Java packages are generated and published using this [GitHub action](https://github.com/guardian/mobile-apps-thrift/blob/main/.github/actions/generate-native-package/action.yml)
+The Swift and TypeScript packages are generated and published using this [GitHub action](https://github.com/guardian/mobile-apps-thrift/blob/main/.github/actions/generate-native-package/action.yml)
 
 - The TypeScript package can be installed from [NPM](https://www.npmjs.com/package/mobile-apps-thrift-typescript)
 - Swift package can be installed with Swift Package Manager from [GitHub](https://github.com/guardian/mobile-apps-thrift-swift)


### PR DESCRIPTION
## What does this change?

- Updates the README with the correct link to the the `apps-rendering` repository
- Removes information in README about Java package publishing. The Java interafaces are compiled locally, without being published to a repository
