### PR TITLE
Trigger a patch release

### DIFF
--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.25.0
+        uses: anothrNick/github-tag-action@1.52.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main

--- a/thrift/trigger-release.txt
+++ b/thrift/trigger-release.txt
@@ -1,0 +1,2 @@
+This file exists only to trigger a release.
+The GitHub Action which triggers releases only runs when there are changes in this directory.


### PR DESCRIPTION
## What does this change?

- Adds a file in the `thrift/` directory to trigger the release GHA (`.github/workflows/generate-packages.yml`) to run. This action only runs on pushes to `main` with changes in the `thrift/` directory.
  - we should be able to specify a `patch` version increase by using the `#patch` tag in the commit message (as in 858a520707f4b2850fdac99a0eb45594fa3dca9c)
- After the patch release has been made, we then need to create a new PR which reverts this change. If we include the `#none` tag in the commit, the revert PR [should not trigger a release](https://github.com/anothrNick/github-tag-action#bumping). We should **not** revert this PR, as that will include a commit with the `#patch` instruction which takes priority over `#none`
  - I have bumped the version of `anothrNick/github-tag-action` which performs versioning, to enable the `#none` instruction
 
## Why?

To enable release of Apps Rendering video support, we need to publish a new version of Bridget so only apps which have support can use Apps Rendering to render articles with videos. There is more information in https://github.com/guardian/dotcom-rendering/issues/6196