### PR TITLE
Revert "Trigger a patch release"

### DIFF
--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.52.0
+        uses: anothrNick/github-tag-action@1.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main

--- a/thrift/trigger-release.txt
+++ b/thrift/trigger-release.txt
@@ -1,2 +1,0 @@
-This file exists only to trigger a release.
-The GitHub Action which triggers releases only runs when there are changes in this directory.


### PR DESCRIPTION
> **Warning**
> When merging this PR, we should include `#none` in the merge commit. This is so the [GitHub Action which manages versioning ](https://github.com/anothrNick/github-tag-action) does **not** bump the version again.

## What does this do?

As described in https://github.com/guardian/dotcom-rendering/issues/6196, we have releasted a patch version of Bridget. In order to do so, we had to create a dummy file in the `thrift/` directory. This PR removes that file.

- Reverts guardian/bridget#88 to remove the dummy file created to trigger the patch release
