### PR TITLE
Remove the file used to trigger a patch release in #88

### DIFF
--- a/thrift/trigger-release.txt
+++ b/thrift/trigger-release.txt
@@ -1,2 +1,0 @@
-This file exists only to trigger a release.
-The GitHub Action which triggers releases only runs when there are changes in this directory.


### PR DESCRIPTION
> **Warning**
> When merging this PR, we should include `#none` in the merge commit. This is so the [GitHub Action which manages versioning ](https://github.com/anothrNick/github-tag-action) does **not** bump the version again. [More info on the use of #none](https://github.com/anothrNick/github-tag-action#bumping)

## What does this do?

As described in https://github.com/guardian/dotcom-rendering/issues/6196, we have releasted a patch version of Bridget. In order to do so, we had to create a dummy file in the `thrift/` directory. This PR removes that file.

- Removes the dummy file created in guardian/bridget#88 
