### PR TITLE
docs: add information about the release process

### DIFF
--- a/.github/workflows/validate-thrift.yml
+++ b/.github/workflows/validate-thrift.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "thrift/**"
 
 jobs:
   validate-thrift:

--- a/README.md
+++ b/README.md
@@ -23,5 +23,28 @@ For Android, Java interfaces for Bridget services are generated at build time [i
 5. If you don't see the published packages, start by inspecting the GitHub action started on the branch that was merged into main
 6. Bump the version in your repo (iOS, Android or apps-rendering) and implement the function or make the function call. Make sure the function is always available in the current environment. This can be done by checking the thrift version number of the webView or native layer
 
+## Releasing Bridget
+
+The GitHub Action which releases Bridget requires an `NPM_TOKEN` and a Personal Access Token (PAT). The PAT needs read/write permissions for the [`guardian/bridget-swift`](https://github.com/guardian/bridget-swift) repository.
+
+### Setting the version bump
+
+Versions are managed by [`github-tag-action`](https://github.com/anothrNick/github-tag-action). The default bump is a `minor` version. However, you can specify what version bump to perform using a token at the end of your merge commit message.
+
+For example, to perform a patch bump, your merge commit message could look like:
+
+```
+Release new version of Bridget. #patch
+```
+
+You can use the following tokens:
+
+- `#patch`
+- `#minor`
+- `#major`
+- `#none`, which will not perform a version bump
+
+For more information, see the [`github-tag-action` docs](https://github.com/anothrNick/github-tag-action#bumping).
+
 ## About the name
 The name Bridget was chosen out of a list of a dozen suggestions, containing mostly bridge related puns.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ For Android, Java interfaces for Bridget services are generated at build time [i
 
 ## Releasing Bridget
 
-The GitHub Action which releases Bridget requires an `NPM_TOKEN` and a Personal Access Token (PAT). The PAT needs read/write permissions for the [`guardian/bridget-swift`](https://github.com/guardian/bridget-swift) repository.
+Bridget is released by the [`generate-packages.yml`](.github/workflows/generate-packages.yml) GitHub Actio. The action requires the following environment variables:
+
+- `NPM_TOKEN`
+- a GitHub Personal Access Token (PAT). The PAT needs read/write permissions for the [`guardian/bridget-swift`](https://github.com/guardian/bridget-swift) repository.
 
 ### Setting the version bump
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bridget is released by the [`generate-packages.yml`](.github/workflows/generate-
 
 ### Setting the version bump
 
-Versions are managed by [`github-tag-action`](https://github.com/anothrNick/github-tag-action). The default bump is a `minor` version. However, you can specify what version bump to perform using a token at the end of your merge commit message.
+Versions are managed by [`github-tag-action`](https://github.com/anothrNick/github-tag-action). The default bump is a `minor` version. However, you can specify what version bump to perform using a known symbol at the end of your merge commit message.
 
 For example, to perform a patch bump, your merge commit message could look like:
 
@@ -40,7 +40,7 @@ For example, to perform a patch bump, your merge commit message could look like:
 Release new version of Bridget. #patch
 ```
 
-You can use the following tokens:
+You can use the following symbols:
 
 - `#patch`
 - `#minor`

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ For Android, Java interfaces for Bridget services are generated at build time [i
 
 ## Releasing Bridget
 
-Bridget is released by the [`generate-packages.yml`](.github/workflows/generate-packages.yml) GitHub Actio. The action requires the following environment variables:
+Bridget is released by the [`generate-packages.yml`](.github/workflows/generate-packages.yml) GitHub Action. The repository needs the following secrets available to the action:
 
 - `NPM_TOKEN`
-- a GitHub Personal Access Token (PAT). The PAT needs read/write permissions for the [`guardian/bridget-swift`](https://github.com/guardian/bridget-swift) repository.
+- `ACCESS_TOKEN`: a GitHub Personal Access Token (PAT). The PAT needs read/write permissions for the [`guardian/bridget-swift`](https://github.com/guardian/bridget-swift) repository. Please use a [Fine Grained PAT](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).
 
 ### Setting the version bump
 


### PR DESCRIPTION
## What does this change?

- Adds documentation about the release process and version increments
- Only runs the "Validate Thrift" GitHub Action if files in the `thrift/` directory have changed