### PR TITLE
Remove the file filter from the generate-packages action

### DIFF
--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -2,8 +2,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "thrift/**"
 
 jobs:
   bump-tag:


### PR DESCRIPTION
## What does this change?

> **Note**
> This PR should be merged with a merge commit with `#patch` at the **end** of the first line

- Removes the file filter from the `generate-packages` GitHub Action
- This will enable us to release from every merge to `main`, not just when files under the `thrift/` directory have changed
