### PR TITLE
Return Boolean from Newsletters sign up

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -131,10 +131,10 @@ service Navigation {
 
 /**
  * Service to manage requests from the weblayer related to newsletter subscriptions.
- * added  version 1.13.0
+ * added  version 2.0.0
  * methods:
- *  - requestSignUp: request to sign up to a newsletter using an email address entered by the user.
+ *  - requestSignUp: request to sign up to a newsletter using an email address entered by the user. Returns `true` if the request was successful, `false` if it failed for any reason. Exceptions thrown will be discarded.
  */
 service Newsletters {
-    void requestSignUp(1: string emailAddress, 2:string newsletterIdentityName)
+    bool requestSignUp(1: string emailAddress, 2:string newsletterIdentityName)
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -66,10 +66,6 @@ struct CommentResponse {
     4: optional string errorCode;
 }
 
-struct NewsletterSignUpResponse {
-    1: required bool success;
-}
-
 enum PurchaseScreenReason {
     hideAds = 0,
     epic = 1
@@ -140,5 +136,5 @@ service Navigation {
  *  - requestSignUp: request to sign up to a newsletter using an email address entered by the user.
  */
 service Newsletters {
-    NewsletterSignUpResponse requestSignUp(1: string emailAddress, 2:string newsletterIdentityName)
+    void requestSignUp(1: string emailAddress, 2:string newsletterIdentityName)
 }


### PR DESCRIPTION
## What does this change?

After some discussion, it was decided that the function definition introduced in https://github.com/guardian/bridget/pull/82 should change to return a plain Boolean rather than the `NewsletterSignUpResponse`, which essentially wrapped up a success Bool anyway.
The agreement was that any failures can be passed back by the native layer through this boolean value, rather than by throwing an exception.

Since this is a breaking change, the proposal is to bump the major version number to 2.0
