### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/dotcom-platform @guardian/android-developers @guardian/ios-developers 


### PR DESCRIPTION
## What does this change?

- make teams `@guardian/dotcom-platform`, `@guardian/android-developers` and `@guardian/ios-developers` codeowners of this repository