### PR TITLE
Add support for generating Android code when Bridget is updated

### DIFF
--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -7,7 +7,7 @@ jobs:
   bump-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.52.0
         env:
@@ -34,7 +34,7 @@ jobs:
     needs: bump-tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/generate-native-package
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
     needs: bump-tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/generate-native-package
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -39,3 +39,13 @@ jobs:
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           platform: "ios"
+
+  generate-android-package:
+    needs: bump-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ./.github/actions/generate-native-package
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+          platform: "android"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is part of the set of work to automate generation of Bridget models for the Android app. At the moment, the models are manually (and sporadically) updated.

This PR adds support for generating Android specific Bridget models in `bridget-android` when the thrift file is updated.

Key changes:

1. Updated `native.sh` to update [`bridget-android`](https://github.com/guardian/bridget-android/) repo with new generated code.
2. Updated `generate-packages.yml` workflow to execute a job for Android

> **Note**
> This PR depends on https://github.com/guardian/bridget-android/pull/1, so should only be merged/tested after that one has been merged in.

**Other PRs in the set**

1. Replace manually generated code with externally provided JAR in the app repository: https://github.com/guardian/android-news-app/pull/9297
2. New repo (`bridget-android`) for hosting generated code: https://github.com/guardian/bridget-android/pull/1
3. Github action on `bridget-android` to create PRs on `android-news-app` with updated Jar files when a new tag is pushed: https://github.com/guardian/bridget-android/pull/2