### PR TITLE
Add isMyGuardianEnabled feature flag to Environment service

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -73,6 +73,7 @@ enum PurchaseScreenReason {
 
 service Environment {
     string nativeThriftPackageVersion()
+    bool isMyGuardianEnabled()
 }
 
 service Commercial {


### PR DESCRIPTION
## What does this change?

Extends PR #105 

For the beta roll-out phase of MyGuardian, apps devs need the option to control whether or not MyGuardian features are visibile in Article Webviews.

We will be performing two checks - bridget version compatibility AND a feature flag on the native client envirionment. This is to allow the bridget version on the app builds to be updated, but to not necessarily show MyGuardian features despite this. 

We are thinking of this as a "feature switch". The other option is the add a boolean to the TagService (bool shouldShowFollowTag) but the suggestion was that a decoupled MyGuardian switch would be neater as assuming it would eventually need to be deprecated. 

## Have we considered potential risks?

This environment switche would hang around depite being deprecated in future. 

