### PR TITLE
Add script to generate TS package for local use

### DIFF
--- a/gen-typescript-local-dist.sh
+++ b/gen-typescript-local-dist.sh
@@ -10,8 +10,7 @@
 # generate TypeScript Thrift files
 node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir dist/bridget --strictUnions ../thrift/native.thrift
 
-cd dist 
-cd bridget
+cd dist/bridget
 
 # create package.json
 npm init -y

--- a/gen-typescript-local-dist.sh
+++ b/gen-typescript-local-dist.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Use this script to generate local TS package files for use in local developement
+
+# Final Step: 
+# navigate to the the local project directory where you want to use 
+# this snapshot and run: yarn link @guardian/bridget
+# More info: https://classic.yarnpkg.com/lang/en/docs/cli/link/
+
+# generate TypeScript Thrift files
+node_modules/.bin/thrift-typescript --target thrift-server --rootDir . --sourceDir thrift --outDir dist/bridget --strictUnions ../thrift/native.thrift
+
+cd dist 
+cd bridget
+
+# create package.json
+npm init -y
+../../node_modules/.bin/json -I -f package.json -e 'this.types="index.d.ts"'
+../../node_modules/.bin/json -I -f package.json -e 'this.name="@guardian/bridget"'
+../../node_modules/.bin/json -I -f package.json -e 'this.version="SNAPSHOT"' 
+
+# generate JavaScript files with type declarations
+../../node_modules/.bin/tsc --init --declaration --target ES2016
+../../node_modules/.bin/tsc
+
+# remove TypeScript files
+ls | grep "^[A-Za-z]*.ts" | xargs rm
+
+
+# creates symlink here: cd ~/.config/yarn/link
+# navigate to the the local project directory you want to use this snapshot in and run: yarn link @guardian/bridget
+yarn link
+ 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adapts the `gen-typescript.sh` script into a local development version that will generate the TS files, prepare lib package info and prep it to be used locally via `yarn link` utility. The exisiting script was also used for publishing to npm which is not desired.  

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
