### PR TITLE
Add write permissions to generate-packages action

### DIFF
--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   bump-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-thrift.yml
+++ b/.github/workflows/validate-thrift.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "thrift/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate-thrift:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of the Continuous Deployment pipeline for Bridget includes the `generate-packages` action. This action decides the next version of Bridget, and tags the repository. For this reason, the action needs write permissions on the repository.