### PR TITLE
Bump ubuntu in Docker to 22.04

### DIFF
--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV THRIFT_VERSION v0.14.0-gu5
 

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV THRIFT_VERSION v0.14.0-gu5
 


### PR DESCRIPTION
Keeping things up to date.

## Testing

This change has been [successfully tested](https://github.com/guardian/bridget/actions/runs/6624957305/job/17994963851?pr=109) in the `validate-thrift` workflow.