### PR TITLE
Pass version as an argument to release scripts

### DIFF
--- a/.github/actions/generate-native-package/action.yml
+++ b/.github/actions/generate-native-package/action.yml
@@ -12,3 +12,4 @@ runs:
     - ${{ inputs.access_token }}
     - ${{ inputs.platform }}
     - ${{ inputs.release_type }}
+    - ${{ inputs.version }}

--- a/.github/actions/generate-native-package/native.sh
+++ b/.github/actions/generate-native-package/native.sh
@@ -4,6 +4,7 @@
 export ACCESS_TOKEN=$1
 export PLATFORM=$2
 export RELEASE_TYPE=$3
+export VERSION=$4
 
 if [ -z "$RELEASE_TYPE" ] || ! [[ "$RELEASE_TYPE" =~ ^(pre)?release$ ]];
 then
@@ -21,17 +22,15 @@ git config --global user.email '<>'
 git clone https://github.com/guardian/bridget.git
 
 cd bridget
-git checkout $GITHUB_REF
-CURRENT_VERSION="$(git describe --tags --abbrev=0)"
 # Add a -branch suffix so the prerelease tag and branch do not have the same name
-PRERELEASE_BRANCH_NAME="$CURRENT_VERSION-branch"
+PRERELEASE_BRANCH_NAME="$VERSION-branch"
 cd ../
 
 # Add version const to thrift file
 echo "" >> bridget/thrift/native.thrift
-echo "const string BRIDGET_VERSION = \"$CURRENT_VERSION\"" >>  bridget/thrift/native.thrift
+echo "const string BRIDGET_VERSION = \"$VERSION\"" >>  bridget/thrift/native.thrift
 
-echo "Publishing $RELEASE_TYPE to platform $PLATFORM with version $CURRENT_VERSION"
+echo "Publishing $RELEASE_TYPE to platform $PLATFORM with version $VERSION"
 # Platform tasks
 if [ "$PLATFORM" == "ios" ]; then
 
@@ -54,14 +53,14 @@ if [ "$PLATFORM" == "ios" ]; then
     cd bridget-swift
     if [[ -n `git diff` ]]; then
         git add Sources/Bridget/*.swift
-        git commit -m "Update Swift models $CURRENT_VERSION"
+        git commit -m "Update Swift models $VERSION"
         if [ "$RELEASE_TYPE" = "prerelease" ];
         then
             git push -u origin $PRERELEASE_BRANCH_NAME
         else
             git push origin main
         fi
-        git tag $CURRENT_VERSION
+        git tag $VERSION
         git push --tags
     fi
 elif [ "$PLATFORM" == "android" ]; then
@@ -94,14 +93,14 @@ elif [ "$PLATFORM" == "android" ]; then
     cd bridget-android
     if [[ -n `git diff` ]]; then
         git add library/src/main/*
-        git commit -m "Update Thrift generated classes $CURRENT_VERSION"
+        git commit -m "Update Thrift generated classes $VERSION"
         if [ "$RELEASE_TYPE" = "prerelease" ];
         then
             git push -u origin $PRERELEASE_BRANCH_NAME
         else
             git push origin main
         fi
-        git tag $CURRENT_VERSION
+        git tag $VERSION
         git push --tags
     fi
 else

--- a/.github/actions/generate-native-package/native.sh
+++ b/.github/actions/generate-native-package/native.sh
@@ -22,6 +22,7 @@ git config --global user.email '<>'
 git clone https://github.com/guardian/bridget.git
 
 cd bridget
+git checkout $GITHUB_REF
 # Add a -branch suffix so the prerelease tag and branch do not have the same name
 PRERELEASE_BRANCH_NAME="$VERSION-branch"
 cd ../

--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -47,6 +47,7 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           platform: "ios"
           release_type: "release"
+          version: ${{ needs.bump-tag.outputs.new_tag }}
 
   generate-android-package:
     needs: bump-tag
@@ -58,3 +59,4 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           platform: "android"
           release_type: "release"
+          version: ${{ needs.bump-tag.outputs.new_tag }}

--- a/.github/workflows/generate-packages.yml
+++ b/.github/workflows/generate-packages.yml
@@ -22,16 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
+          cache: "npm"
+          node-version-file: ".nvmrc"
+
       - name: install
         run: npm install
+
       - name: generate and publish
-        run: ./gen-typescript.sh release
+        run: ./gen-typescript.sh release ${VERSION}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.bump-tag.outputs.new_tag }}
 
   generate-swift-package:
     needs: bump-tag

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -41,27 +41,27 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.get_version.outputs.version }}
 
-  # generate-swift-package:
-  #   needs: get_version
-  #   runs-on: ubuntu-latest
-  #   if: "github.event.release.prerelease"
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/generate-native-package
-  #       with:
-  #         access_token: ${{ secrets.ACCESS_TOKEN }}
-  #         platform: "ios"
-  #         release_type: "prerelease"
-  #         version: ${{ needs.get_version.outputs.version }}
+  generate-swift-package:
+    needs: get_version
+    runs-on: ubuntu-latest
+    if: "github.event.release.prerelease"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/generate-native-package
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+          platform: "ios"
+          release_type: "prerelease"
+          version: ${{ needs.get_version.outputs.version }}
 
-  # generate-android-package:
-  #   needs: get_version
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/generate-native-package
-  #       with:
-  #         access_token: ${{ secrets.ACCESS_TOKEN }}
-  #         platform: "android"
-  #         release_type: "prerelease"
-  #         version: ${{ needs.get_version.outputs.version }}
+  generate-android-package:
+    needs: get_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/generate-native-package
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+          platform: "android"
+          release_type: "prerelease"
+          version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -12,7 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Version from latest tag
-        run: echo "version=$(git describe --tags --abbrev=0)\n" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          echo $VERSION
+          echo "version=$VERSION\n" >> $GITHUB_OUTPUT
 
   generate-typescript-package:
     needs: version
@@ -20,39 +23,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
+
       - name: install
         run: npm install
+
       - name: generate and publish
         run: ./gen-typescript.sh prerelease ${VERSION}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.version.outputs.version }}
 
-  generate-swift-package:
-    needs: version
-    runs-on: ubuntu-latest
-    if: "github.event.release.prerelease"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/generate-native-package
-        with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
-          platform: "ios"
-          release_type: "prerelease"
-          version: ${{ needs.version.outputs.version }}
+  # generate-swift-package:
+  #   needs: version
+  #   runs-on: ubuntu-latest
+  #   if: "github.event.release.prerelease"
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/generate-native-package
+  #       with:
+  #         access_token: ${{ secrets.ACCESS_TOKEN }}
+  #         platform: "ios"
+  #         release_type: "prerelease"
+  #         version: ${{ needs.version.outputs.version }}
 
-  generate-android-package:
-    needs: version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/generate-native-package
-        with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
-          platform: "android"
-          release_type: "prerelease"
-          version: ${{ needs.version.outputs.version }}
+  # generate-android-package:
+  #   needs: version
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/generate-native-package
+  #       with:
+  #         access_token: ${{ secrets.ACCESS_TOKEN }}
+  #         platform: "android"
+  #         release_type: "prerelease"
+  #         version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -21,7 +21,7 @@ jobs:
           echo "version=$VERSION\n" >> $GITHUB_OUTPUT
 
   generate-typescript-package:
-    needs: version
+    needs: get_version
     if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +42,7 @@ jobs:
           VERSION: ${{ needs.get_version.outputs.version }}
 
   # generate-swift-package:
-  #   needs: version
+  #   needs: get_version
   #   runs-on: ubuntu-latest
   #   if: "github.event.release.prerelease"
   #   steps:
@@ -52,10 +52,10 @@ jobs:
   #         access_token: ${{ secrets.ACCESS_TOKEN }}
   #         platform: "ios"
   #         release_type: "prerelease"
-  #         version: ${{ needs.version.outputs.version }}
+  #         version: ${{ needs.get_version.outputs.version }}
 
   # generate-android-package:
-  #   needs: version
+  #   needs: get_version
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v4
@@ -64,4 +64,4 @@ jobs:
   #         access_token: ${{ secrets.ACCESS_TOKEN }}
   #         platform: "android"
   #         release_type: "prerelease"
-  #         version: ${{ needs.version.outputs.version }}
+  #         version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -6,7 +6,16 @@ permissions:
   contents: write
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Version from latest tag
+        run: echo "version=$(git describe --tags --abbrev=0)\n" >> $GITHUB_OUTPUT
+
   generate-typescript-package:
+    needs: version
     if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
@@ -18,11 +27,13 @@ jobs:
       - name: install
         run: npm install
       - name: generate and publish
-        run: ./gen-typescript.sh prerelease
+        run: ./gen-typescript.sh prerelease ${VERSION}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
 
   generate-swift-package:
+    needs: version
     runs-on: ubuntu-latest
     if: "github.event.release.prerelease"
     steps:
@@ -32,8 +43,10 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           platform: "ios"
           release_type: "prerelease"
+          version: ${{ needs.version.outputs.version }}
 
   generate-android-package:
+    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,3 +55,4 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           platform: "android"
           release_type: "prerelease"
+          version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -6,12 +6,15 @@ permissions:
   contents: write
 
 jobs:
-  version:
+  get_version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version_step.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Version from latest tag
+        id: version_step
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           echo $VERSION
@@ -36,7 +39,7 @@ jobs:
         run: ./gen-typescript.sh prerelease ${VERSION}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          VERSION: ${{ needs.version.outputs.version }}
+          VERSION: ${{ needs.get_version.outputs.version }}
 
   # generate-swift-package:
   #   needs: version

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           echo $VERSION
-          echo "version=$VERSION\n" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   generate-typescript-package:
     needs: get_version

--- a/gen-typescript.sh
+++ b/gen-typescript.sh
@@ -1,9 +1,15 @@
 RELEASE_TYPE=$1
+VERSION=$2
 
 if [ -z "$RELEASE_TYPE" ] || ! [[ "$RELEASE_TYPE" =~ ^(pre)?release$ ]];
 then
-    echo "Please specify a release type: prerelease or release";
-    echo "e.g gen-typescript.sh prerelease";
+    echo "Please specify a release type as the 1st argument: prerelease or release";
+    exit 1
+fi
+
+if [ -z "$VERSION" ];
+then
+    echo "Please specify a version as the 2nd argument"
     exit 1
 fi
 
@@ -25,17 +31,14 @@ echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 # remove TypeScript files
 ls | grep "^[A-Za-z]*.ts" | xargs rm
 
-# use repo tag for version
-CURRENT_FULL_VERSION="$(git describe --tags --abbrev=0)"
-
 # publish to npm
-npm version ${CURRENT_FULL_VERSION}
+npm version ${VERSION}
 
 if [ "$RELEASE_TYPE" = "prerelease" ];
 then
-    echo "Publishing prerelease with version $CURRENT_FULL_VERSION"
+    echo "Publishing prerelease with version $VERSION"
     npm publish --tag snapshot
 else
-    echo "Publishing full release with version $CURRENT_FULL_VERSION"
+    echo "Publishing full release with version $VERSION"
     npm publish --access public
 fi


### PR DESCRIPTION
## What does this change?

- Passes which version to release as an argument to the scripts that perform the release, instead of determining the version inside each script. The version is calculated in the GitHub action.

## Why?

Determining the version in each script is a bit confusing, and tightly couples each script to a specific set of conventions and available tools. By passing the version into the scripts as an input, we remove some of this confusion and centralise it in the GitHub Actions workflows.

## Testing

- [GitHub prerelease](https://github.com/guardian/bridget/releases/tag/v0.0.0-2024-02-20-VERSION-2)
- [Action run](https://github.com/guardian/bridget/actions/runs/7978363096)

Closes https://github.com/guardian/bridget/issues/119