### PR TITLE
Fix changesets release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Create release in GitHub
         uses: changesets/action@v1
+        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
         with:
           # We've already published above, but changesets needs this command to exit successfully to create the release in GitHub
-          publish: exit 0
+          publish: node -e true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

- As mentioned in #115, implementing something that only runs on merges to `main` can be tricky! In this case, we should also make sure to only try and create a Release in GitHub if the version has changed. Additionally, the `publish` script needs to be executable. Using `node -e true` is executable, whereas `exit 0` is not!