### PR TITLE
Authenticate release workflows using a GitHub App

### DIFF
--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -46,10 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     if: "github.event.release.prerelease"
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: guardian
+          repositories: "bridget,bridget-swift"
+
       - uses: actions/checkout@v4
       - uses: ./.github/actions/generate-native-package
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ steps.app-token.outputs.token }}
           platform: "ios"
           release_type: "prerelease"
           version: ${{ needs.get_version.outputs.version }}
@@ -58,10 +66,18 @@ jobs:
     needs: get_version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: guardian
+          repositories: "bridget,bridget-android"
+
       - uses: actions/checkout@v4
       - uses: ./.github/actions/generate-native-package
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ steps.app-token.outputs.token }}
           platform: "android"
           release_type: "prerelease"
           version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: guardian
+          repositories: "bridget,bridget-android,bridget-swift"
+
       - uses: actions/checkout@v4
         with:
           # Get the latest 2 commits so we can compare the versions in package.json
@@ -39,7 +47,7 @@ jobs:
         uses: changesets/action@v1
         id: changesets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # The steps below here only run when there's something to publish
 
@@ -54,7 +62,7 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
         uses: ./.github/actions/generate-native-package
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ steps.app-token.outputs.token }}
           platform: "android"
           release_type: "release"
           version: ${{ steps.version_check.outputs.version }}
@@ -63,7 +71,7 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
         uses: ./.github/actions/generate-native-package
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ steps.app-token.outputs.token }}
           platform: "ios"
           release_type: "release"
           version: ${{ steps.version_check.outputs.version }}
@@ -75,4 +83,4 @@ jobs:
           # We've already published above, but changesets needs this command to exit successfully to create the release in GitHub
           publish: node -e true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What does this change?

We use GitHub Actions Workflows to deploy releases of Bridget. Part of the release process is pushing tags and branches to `guardian/bridget,` `guardian/bridget-swift` and `guardian/bridget-android`. Pushing to repositories other than `guardian/bridget` require an access token. Previously, this was provided as a fine-grained Personal Access Token tied to an individual account. This is less than ideal, and so instead we have:

- Created a GitHub App and installed it to the `guardian/bridget` repository with read & write access to `guardian/bridget,` `guardian/bridget-swift` and `guardian/bridget-android`
- Updated the release and prerelease workflows to use this app to obtain a token which can be used to authenticate git operations to these repositories.

Paired with @alinaboghiu!

Tested in [this prerelease](https://github.com/guardian/bridget/actions/runs/8083288985).

Closes #103