### PR TITLE
Add `isSignedIn` and `signIn` methods to `User` service

### DIFF
--- a/.changeset/quiet-dolls-fold.md
+++ b/.changeset/quiet-dolls-fold.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Add `isSignedIn` and `signIn` methods to `User` service

--- a/.changeset/thirty-grapes-repair.md
+++ b/.changeset/thirty-grapes-repair.md
@@ -1,5 +1,0 @@
----
-"bridget": minor
----
-
-Adds sign in and is signed in functions and sign in reasons and referrers

--- a/.changeset/thirty-grapes-repair.md
+++ b/.changeset/thirty-grapes-repair.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Adds sign in and is signed in functions and sign in reasons and referrers

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -103,7 +103,9 @@ service User {
     bool isPremium(),
     list<string> filterSeenArticles(1:list<string> articleIds),
     string discussionId(),
-    bool doesCcpaApply()
+    bool doesCcpaApply(),
+    bool isSignedIn(),
+    void signIn(),
 }
 
 service Gallery {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -71,6 +71,22 @@ enum PurchaseScreenReason {
     epic = 1
 }
 
+enum SignInScreenReason {
+    accessDiscussion = 0
+    postComment = 1,
+    recommendComment = 2,
+    replyToComment = 3,
+    reportComment = 4
+}
+
+enum SignInScreenReferrer {
+    accessDiscussion = 0
+    postComment = 1,
+    recommendComment = 2,
+    replyToComment = 3,
+    reportComment = 4
+}
+
 service Environment {
     string nativeThriftPackageVersion()
     bool isMyGuardianEnabled()
@@ -105,7 +121,7 @@ service User {
     string discussionId(),
     bool doesCcpaApply(),
     bool isSignedIn(),
-    void signIn(),
+    void signIn(1:SignInScreenReason reason, 2:SignInScreenReferrer referrer),
 }
 
 service Gallery {


### PR DESCRIPTION
## What does this change?

This change:

- Add `signIn` methods to `User` service. DCR can use this method to sign in or register users in-article. This will be used in the discussion app. 

- Add `isSignedIn` method to `User` service. DCR can use these methods to decide what action to perform for certain events (like a user recommending a comment).


When a user interacts with the UI, they want to see updates in the UI. However, if the interaction requires the user to sign in first (like recommending a comment), the Bridget callback channel might time out so we can’t update the UI. The current timeout is 30 seconds. 

~~To get around this, the web view should initiate the sign in flow when the user performs an authenticated action. Once the user is signed in, DCR/the user can retry the authenticated action.~~  To get around this, the native layers will refresh the web view once sign in is successful.

