### PR TITLE
Refactor releases to run tasks in parallel

### DIFF
--- a/.changeset/silver-cooks-report.md
+++ b/.changeset/silver-cooks-report.md
@@ -1,0 +1,5 @@
+---
+"bridget": patch
+---
+
+Version bump to trigger a release

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -50,9 +50,9 @@ jobs:
       matrix:
         include:
           - platform: android
-            repo: bridget-android
+            repository: bridget-android
           - platform: ios
-            repo: bridget-swift
+            repository: bridget-swift
 
     steps:
       - uses: actions/create-github-app-token@v1
@@ -61,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ format('bridget,{0}', matrix.repo) }} # e.g "bridget,bridget-swift"
+          repositories: ${{ format('bridget,{0}', matrix.repository) }} # e.g "bridget,bridget-swift"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ join(fromJSON('["bridget", matrix.repo]')) }}
+          repositories: ${{ format('bridget,${0}', matrix.repo) }}
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ format('bridget,{0}', matrix.repo) }}
+          repositories: ${{ format('bridget,{0}', matrix.repo) }} # e.g "bridget,bridget-swift"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -41,10 +41,15 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.get_version.outputs.version }}
 
-  generate-swift-package:
+  native-release:
     needs: get_version
     runs-on: ubuntu-latest
-    if: "github.event.release.prerelease"
+
+    strategy:
+      fail-fast: false # do not cancel other in progress jobs if any single one fails
+      matrix:
+        platform: [ios, android]
+
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -52,32 +57,13 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: "bridget,bridget-swift"
+          repositories: "bridget,bridget-swift,bridget-android"
 
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/generate-native-package
         with:
           access_token: ${{ steps.app-token.outputs.token }}
-          platform: "ios"
-          release_type: "prerelease"
-          version: ${{ needs.get_version.outputs.version }}
-
-  generate-android-package:
-    needs: get_version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: guardian
-          repositories: "bridget,bridget-android"
-
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/generate-native-package
-        with:
-          access_token: ${{ steps.app-token.outputs.token }}
-          platform: "android"
+          platform: ${{ matrix.platform }}
           release_type: "prerelease"
           version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ format('bridget,${0}', matrix.repo) }}
+          repositories: ${{ format('bridget,{0}', matrix.repo) }}
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -48,7 +48,11 @@ jobs:
     strategy:
       fail-fast: false # do not cancel other in progress jobs if any single one fails
       matrix:
-        platform: [ios, android]
+        include:
+          - platform: android
+            repo: bridget-android
+          - platform: ios
+            repo: bridget-swift
 
     steps:
       - uses: actions/create-github-app-token@v1
@@ -57,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: "bridget,bridget-swift,bridget-android"
+          repositories: ${{ join(['bridget', matrix.repo]) }}
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ join(['bridget', matrix.repo]) }}
+          repositories: ${{ join(fromJSON('["bridget", matrix.repo]')) }}
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: ${{ format('bridget,{0}', matrix.repository) }}
+          repositories: ${{ format('bridget,{0}', matrix.repository) }} # e.g "bridget,bridget-swift"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,8 @@ jobs:
           release_type: "release"
           version: ${{ needs.version_check.outputs.version }}
 
-  manage_release:
-    name: Create release PR or Release Packages
+  create_github_release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
     needs: [npm_release, native_release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,78 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  manage_release:
-    name: Create release PR or Release Packages
+  version_check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    outputs:
+      versionChanged: ${{ steps.get_version.outputs.versionChanged }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Get the latest 2 commits so we can compare the versions in package.json
+          fetch-depth: 2
+
+      - name: Get version
+        id: get_version
+        run: |
+          PREV_VERSION=$(git checkout -q HEAD^ && npm pkg get version && git switch -q -)
+          CURR_VERSION=$(npm pkg get version)
+          echo "versionChanged=$(if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+          echo "version=$(echo $CURR_VERSION | xargs)" >> $GITHUB_OUTPUT
+
+  changesets_release_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version-file: ".nvmrc"
+
+      - run: npm install
+
+      - uses: changesets/action@v1
+        id: changesets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm_release:
+    runs-on: ubuntu-latest
+    needs: [changesets_release_pr, version_check]
+    if: needs.changesets_release_pr.outputs.hasChangesets == 'false' && needs.version_check.outputs.versionChanged == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version-file: ".nvmrc"
+
+      - run: npm install
+
+      - name: Publish NPM
+        run: ./gen-typescript.sh release ${VERSION}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.version_check.outputs.version }}
+
+  native_release:
+    runs-on: ubuntu-latest
+    needs: [changesets_release_pr, version_check]
+    if: needs.changesets_release_pr.outputs.hasChangesets == 'false' && needs.version_check.outputs.versionChanged == 'true'
+    strategy:
+      fail-fast: false # do not cancel other in progress jobs if any single one fails
+      matrix:
+        include:
+          - platform: android
+            repository: bridget-android
+          - platform: ios
+            repository: bridget-swift
+
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -19,68 +84,28 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: guardian
-          repositories: "bridget,bridget-android,bridget-swift"
+          repositories: ${{ format('bridget,{0}', matrix.repository) }}
 
       - uses: actions/checkout@v4
-        with:
-          # Get the latest 2 commits so we can compare the versions in package.json
-          fetch-depth: 2
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          cache: "npm"
-          node-version-file: ".nvmrc"
-
-      - name: Check if package version has changed
-        id: version_check
-        # Check if the version has changed between this commit's package.json and the previous commit's package.json
-        run: |
-          PREV_VERSION=$(git checkout -q HEAD^ && npm pkg get version && git switch -q -)
-          CURR_VERSION=$(npm pkg get version)
-          echo "versionChanged=$(if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
-          echo "version=$(echo $CURR_VERSION | xargs)" >> $GITHUB_OUTPUT
-
-      - run: npm install
-
-      - name: Create Release Pull Request
-        uses: changesets/action@v1
-        id: changesets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # The steps below here only run when there's something to publish
-
-      - name: Publish NPM
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
-        run: ./gen-typescript.sh release ${VERSION}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          VERSION: ${{ steps.version_check.outputs.version }}
-
-      - name: Publish Android
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
+      - name: Release
         uses: ./.github/actions/generate-native-package
         with:
           access_token: ${{ steps.app-token.outputs.token }}
-          platform: "android"
+          platform: ${{ matrix.platform }}
           release_type: "release"
-          version: ${{ steps.version_check.outputs.version }}
+          version: ${{ needs.version_check.outputs.version }}
 
-      - name: Publish iOS
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
-        uses: ./.github/actions/generate-native-package
-        with:
-          access_token: ${{ steps.app-token.outputs.token }}
-          platform: "ios"
-          release_type: "release"
-          version: ${{ steps.version_check.outputs.version }}
-
+  manage_release:
+    name: Create release PR or Release Packages
+    runs-on: ubuntu-latest
+    if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
+    needs: [npm_release, native_release]
+    steps:
       - name: Create release in GitHub
         uses: changesets/action@v1
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
         with:
           # We've already published above, but changesets needs this command to exit successfully to create the release in GitHub
           publish: node -e true
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

- Refactors the release workflow to run the typescript, native android and native iOS jobs in parallel. Previously, these were run as one job which meant it was not possible to retry any part without running all the others. This gives us the flexibility to e.g retry the android release if it fails for some reason
- Refactors the native release to a matrix job, as the configuration is essentially unchanged between iOS and Android

The previous release failed for iOS and Android, but succeeded for NPM. However, due to the workflow design, we can't retry the iOS and Android parts independently. The NPM step now fails because that version has already been released, and so the rest of the workflow does not run.

## How to test / why is this a `patch` version bump?

As usual, testing the main release is tricky as it requires a merge to `main`. Coupled with conditionals determining which jobs run and when, we need to make a version bump to trigger a release.