### PR TITLE
Fix syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,8 @@ jobs:
   create_github_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.versionChanged == 'true'
-    needs: [npm_release, native_release]
+    if: needs.changesets_release_pr.outputs.hasChangesets == 'false' && needs.version_check.outputs.versionChanged == 'true'
+    needs: [changesets_release_pr, version_check, npm_release, native_release]
     steps:
       - name: Create release in GitHub
         uses: changesets/action@v1


### PR DESCRIPTION
Adds `changesets_release_pr` and `version_check` to the final job's `needs` array, so they can be referenced in the condition that determines whether the job should run.