### PR TITLE
Fix "create release" step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
     if: needs.changesets_release_pr.outputs.hasChangesets == 'false' && needs.version_check.outputs.versionChanged == 'true'
     needs: [changesets_release_pr, version_check, npm_release, native_release]
     steps:
+      - uses: actions/checkout@v4
       - name: Create release in GitHub
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Runs `actions/checkout` to check out the repository before trying to create the release, otherwise this step [fails](https://github.com/guardian/bridget/actions/runs/8252544867/job/22572480751)