### PR TITLE
Do not run native prerelease job for non prereleases

### DIFF
--- a/.github/workflows/generate-prerelease.yml
+++ b/.github/workflows/generate-prerelease.yml
@@ -43,6 +43,7 @@ jobs:
 
   native-release:
     needs: get_version
+    if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
The prerelease jobs should not run for regular releases.