### PR TITLE
Fix tags and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           PREV_VERSION=$(git checkout -q HEAD^ && npm pkg get version && git switch -q -)
           CURR_VERSION=$(npm pkg get version)
           echo "versionChanged=$(if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
-          echo "version=$(echo $CURR_VERSION | xargs)" >> $GITHUB_OUTPUT
+          echo "version=v$(echo $CURR_VERSION | xargs)" >> $GITHUB_OUTPUT
 
   changesets_release_pr:
     runs-on: ubuntu-latest
@@ -105,10 +105,19 @@ jobs:
     needs: [changesets_release_pr, version_check, npm_release, native_release]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Tag local repository
+        run: |
+          git tag -m "$VERSION"
+        env:
+          VERSION: ${{ needs.version_check.outputs.version }}
+
       - name: Create release in GitHub
         uses: changesets/action@v1
         with:
-          # We've already published above, but changesets needs this command to exit successfully to create the release in GitHub
-          publish: node -e true
+          # The actual release process has already completed in jobs npm_release and native_release
+          # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
+          # See https://github.com/changesets/action/blob/63ffd93140be6000b385d611d886a82c86214719/src/run.ts#L176
+          publish: node -e "console.log('New tag:');"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This tag will get pushed by the Changesets action in the next step!
       - name: Tag local repository
         run: |
-          git tag -m "$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -m "$VERSION" $VERSION
         env:
           VERSION: ${{ needs.version_check.outputs.version }}
 
@@ -118,6 +121,6 @@ jobs:
           # The actual release process has already completed in jobs npm_release and native_release
           # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
           # See https://github.com/changesets/action/blob/63ffd93140be6000b385d611d886a82c86214719/src/run.ts#L176
-          publish: node -e "console.log('New tag:');"
+          publish: "echo 'New tag:'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

We've gone a little off-piste with Changesets because we don't use the `npx changeset ...` commands to actually perform the release, because we're doing more than Changesets is built to handle. But we still want it to manage tagging and creating a GitHub Release for us! This PR fixes (hopefully..) the final remaining issues.

This change:

- Adds a step to tag the repository. This would normally be done by calling `npm version` within the Changesets action. However, we manage the NPM release process in a separate job, and so the tag is lost
- "Tricks" the Changesets action into creating a release in GitHub for us by outputting `"New tag:"` in the `publish` command. The changesets action [looks out](https://github.com/changesets/action/blob/main/src/run.ts#L176) for this string in the output to know whether it should create a release. This is a bit hacky but I think it's preferable to managing GitHub releases ourselves.