### PR TITLE
Add `recommend` to Discussion service

### DIFF
--- a/.changeset/tasty-dolls-protect.md
+++ b/.changeset/tasty-dolls-protect.md
@@ -1,5 +1,5 @@
 ---
-"bridget": minor
+"bridget": major
 ---
 
 Replace previous disucssion service stubs with new recommend signature

--- a/.changeset/tasty-dolls-protect.md
+++ b/.changeset/tasty-dolls-protect.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Replace previous disucssion service stubs with new recommend signature

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -59,13 +59,6 @@ union Metric {
     3: MetricFont font;
 }
 
-struct CommentResponse {
-    1: required string status;
-    2: required i32 statusCode;
-    3: required string message;
-    4: optional string errorCode;
-}
-
 enum PurchaseScreenReason {
     hideAds = 0,
     epic = 1
@@ -137,12 +130,24 @@ service Metrics {
     void sendMetrics(1:list<Metric> metrics)
 }
 
+struct DiscussionApiResponse {
+    1: required string status;
+    2: required i32 statusCode;
+    3: required string message;
+    4: optional string errorCode;
+}
+
+enum DiscussionNativeError {
+    UNKNOWN_ERROR = 0
+}
+
+union DiscussionResponse {
+    1: DiscussionApiResponse response;
+    2: DiscussionNativeError error;
+}
+
 service Discussion {
-    string preview(1:string body),
-    bool isDiscussionEnabled(),
-    bool recommend(1:i32 commentId),
-    CommentResponse comment(1:string shortUrl, 2:string body),
-    CommentResponse reply(1:string shortUrl, 2:string body, 3:i32 parentCommentId)
+    DiscussionResponse recommend(1:string commentId),
 }
 
 service Analytics {


### PR DESCRIPTION
The previous stub was unused. This adds relevant types and signatures for the `recommend` method.

This PR is based off commits in #111. This change adds `recommend` by itself so that it can be implemented soon by Android and iOS.

We can release the remaining Discussion methods in another Bridget version, so the platforms can implement them when ready. This will enable us to render more articles with discussion using DCAR, more quickly.