### PR TITLE
Fix actions versions syntax

### DIFF
--- a/.github/workflows/validate-thrift.yml
+++ b/.github/workflows/validate-thrift.yml
@@ -15,5 +15,5 @@ jobs:
   validate-thrift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/validate-thrift


### PR DESCRIPTION
Fixup of #155, [which failed](https://github.com/guardian/bridget/actions/runs/8735698387)