### PR TITLE
Add `sendVideoEvent` and `fullscreen` methods to `Videos` service

### DIFF
--- a/.changeset/silver-lemons-look.md
+++ b/.changeset/silver-lemons-look.md
@@ -1,0 +1,9 @@
+---
+"bridget": major
+---
+
+Add sendVideoEvent and fullscreen methods to Videos service
+
+The sendVideoEvent method is required to send video events from webviews to the native layer so that they can be forwarded to Ophan. Webviews do not have access to the Ophan page view id and the native layer will also handle offline mode and batching of requests.
+
+The fullscreen method is required for Android as the web YouTube player performs a no-op for fullscreen on Android. We therefore need to instruct the native layer to resize the player into a fullscreen view.

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -70,6 +70,7 @@ enum MediaEvent {
 }
 
 struct VideoEvent {
+    /** for YouTube Atoms videoId should the atom id  */
     1: required string videoId;
     2: required MediaEvent event;
 }
@@ -140,6 +141,7 @@ service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
     void updateVideos(1:list<VideoSlot> videoSlots),
     void sendVideoEvent(1:VideoEvent videoEvent),
+    /** Android only */
     void fullscreen(),
 }
 

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -53,15 +53,25 @@ struct MetricFont {
     3: optional string name;
 }
 
-struct VideoEvent {
-    1: required string videoId;
-    2: required string event;
-}
-
 union Metric {
     1: MetricPaint firstPaint;
     2: MetricPaint firstContentfulPaint;
     3: MetricFont font;
+}
+
+enum MediaEvent {
+    request = 0,
+    ready = 1,
+    play = 2,
+    percent25 = 3,
+    percent50 = 4,
+    percent75 = 5,
+    end = 6
+}
+
+struct VideoEvent {
+    1: required string videoId;
+    2: required MediaEvent event;
 }
 
 enum PurchaseScreenReason {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -53,6 +53,11 @@ struct MetricFont {
     3: optional string name;
 }
 
+struct VideoEvent {
+    1: required string videoId;
+    2: required string event;
+}
+
 union Metric {
     1: MetricPaint firstPaint;
     2: MetricPaint firstContentfulPaint;
@@ -123,7 +128,8 @@ service Gallery {
 
 service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
-    void updateVideos(1:list<VideoSlot> videoSlots)
+    void updateVideos(1:list<VideoSlot> videoSlots),
+    void sendVideoEvent(1:VideoEvent videoEvent),
 }
 
 service Metrics {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -140,6 +140,7 @@ service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
     void updateVideos(1:list<VideoSlot> videoSlots),
     void sendVideoEvent(1:VideoEvent videoEvent),
+    void fullscreen(),
 }
 
 service Metrics {


### PR DESCRIPTION
## What does this change?

Add `sendVideoEvent` and `fullscreen` methods to `Videos` service

The `sendVideoEvent` method is required to send video events from webviews to the native layer so that they can be forwarded to Ophan. Webviews do not have access to the Ophan page view id and the native layer will also handle offline mode and batching of requests.

The `fullscreen` method is required for Android as the web YouTube player performs a no-op for fullscreen on Android. We therefore need to instruct the native layer to resize the player into a fullscreen view.



