### PR TITLE
Add `id` to video `fullscreen` method

### DIFF
--- a/.changeset/slow-mails-prove.md
+++ b/.changeset/slow-mails-prove.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Add id to video fullscreen method

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -142,7 +142,7 @@ service Videos {
     void updateVideos(1:list<VideoSlot> videoSlots),
     void sendVideoEvent(1:VideoEvent videoEvent),
     /** Android only */
-    void fullscreen(),
+    void fullscreen(1:string id),
 }
 
 service Metrics {


### PR DESCRIPTION
## What does this change?

Add `id` to video `fullscreen` method

We need a video identifier to be passed to the native layer so it can determine the right video to make fullscreen.

This method is not currently used in PROD by any platform so it is safe to do a minor bump.