### PR TITLE
Ravi/video fullscreen

### DIFF
--- a/.changeset/kind-sloths-raise.md
+++ b/.changeset/kind-sloths-raise.md
@@ -1,0 +1,7 @@
+---
+"bridget": minor
+---
+
+Replace fullscreen() method with setFullscreen(bool)
+
+Add method webFullscreen() to decide if the webview should handle fullscreen behaviour

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -142,7 +142,7 @@ service Videos {
     void updateVideos(1:list<VideoSlot> videoSlots),
     void sendVideoEvent(1:VideoEvent videoEvent),
     /** Android only */
-    void fullscreen(),
+    void setFullscreen(1:bool isFullscreen),
 }
 
 service Metrics {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -143,6 +143,8 @@ service Videos {
     void sendVideoEvent(1:VideoEvent videoEvent),
     /** Android only */
     void setFullscreen(1:bool isFullscreen),
+    /** Android requires the web layer to resize and style the player for fullscreen */
+    bool webFullscreen(),
 }
 
 service Metrics {


### PR DESCRIPTION
## What does this change?

Replace `fullscreen()` method with `setFullscreen(bool)` which will be invoked when fullscreen is toggled and will be passed the the fullscreen state i.e active or inactive.

Add method `webFullscreen()` so the web layer can decide if it should handle fullscreen behaviour. This is required for Android as default YouTube player fullscreen behaviour is a no-op on that platform.


