### PR TITLE
Update Dockerfiles to point to Apache Thrift

### DIFF
--- a/.changeset/modern-beers-heal.md
+++ b/.changeset/modern-beers-heal.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Update Dockerfiles to point to Apache Thrift

--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV THRIFT_VERSION v0.21.0
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 		pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV THRIFT_VERSION v0.21.0
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 	pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \


### PR DESCRIPTION
## What does this change?

This is one of the necessary stages in decommissioning french-thrift, since we have ascertained [here](https://docs.google.com/document/d/1JBGej-2Adn3UrzRMNSlGYn5vWA3Gu4oD4b1ZtyPfWXU/edit?tab=t.0) that it is no longer needed. The full list of steps required to complete this process is documented [here](https://theguardian.atlassian.net/browse/LIVE-7287).

This PR updates the Dockerfiles (used to describe the environment needed to auto-generate the Swift Package) to point to the latest version of Apache Thrift instead of French Thrift.

## How to test

When all the related PRs are in the right state, we'll need to create a new release of Bridget that we can then use in the iOS repo. We'll then do a smoke test of the app to verify that everything is working as expected.