### PR TITLE
Revert "Update Dockerfiles to point to Apache Thrift"

### DIFF
--- a/.changeset/modern-beers-heal.md
+++ b/.changeset/modern-beers-heal.md
@@ -1,5 +1,0 @@
----
-"bridget": minor
----
-
-Update Dockerfiles to point to Apache Thrift

--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV THRIFT_VERSION v0.21.0
+ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 		pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV THRIFT_VERSION v0.21.0
+ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 	pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \


### PR DESCRIPTION
Reverts guardian/bridget#175

After I merged guardian/bridget#175, the [validate-thrift](https://github.com/guardian/bridget/actions/runs/12141551063) GitHub Action in this repo failed. A bit of digging led me to [this](https://github.com/apache/thrift/pull/1997) closed PR in the Apache Thrift repo by David Furey from March 2020. 

From what I can see, these changes never got merged into Apache Thrift, but were made in the French Thrift repo (as [commits](https://github.com/apache/thrift/compare/master...guardian:french-thrift:mobile-apps) straight to master, rather than as PRs), so we can't just do a straight swap of French Thrift for Apache Thrift. 

I'm reverting this PR for now while I consider the best next steps, which might be to resubmit the [original](https://github.com/apache/thrift/pull/1997) PR introducing an async server implementation for Swift to Apache Swift. Alternatively, we could update French Thrift to the latest Apache Thrift version, which might eliminate the vulnerabilities that started this process. 