### PR TITLE
Test update to french-thrift v0.21.0

### DIFF
--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-prerelease
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-prerelease
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/.github/workflows/validate-thrift.yml
+++ b/.github/workflows/validate-thrift.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "thrift/**"
+    # paths:
+    #  - "thrift/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
This is a test PR to check that the prerelease of french-thrift (in which we update the fork to Apache Thrift v0.21.0) works.
See https://github.com/guardian/french-thrift/pull/14 for more details. 