### PR TITLE
Update to french-thrift@v0.21.0-gu1

### DIFF
--- a/.changeset/slimy-actors-draw.md
+++ b/.changeset/slimy-actors-draw.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Update to french-thrift@v0.21.0-gu1

--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-gu1
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-gu1
 
 RUN apt-get update
 RUN apt-get install -y git


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/thrift-swift/pull/10, we update guardian/thrift-swift to point to the latest version of french-thrift. 

This PR updates the Dockerfiles (used to describe the environment needed to auto-generate the Swift Package) to point to the latest version of french-thrift.

## How to test

When all the related PRs are in the right state, we'll need to create a new release of Bridget that we can then use in the iOS repo. We'll then do a smoke test of the app to verify that everything is working as expected.
