### PR TITLE
Update to french-thrift@v0.21.0-gu2

### DIFF
--- a/.changeset/loud-penguins-taste.md
+++ b/.changeset/loud-penguins-taste.md
@@ -1,0 +1,5 @@
+---
+"bridget": minor
+---
+
+Update to french-thrift@v0.21.0-gu2

--- a/.github/actions/generate-native-package/Dockerfile
+++ b/.github/actions/generate-native-package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-gu2
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/.github/actions/validate-thrift/Dockerfile
+++ b/.github/actions/validate-thrift/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-gu2
 
 RUN apt-get update
 RUN apt-get install -y git


### PR DESCRIPTION
## What does this change?

This PR updates the Dockerfiles (used to describe the environment needed to auto-generate the Swift Package) to point to the [latest version](https://github.com/guardian/french-thrift/releases/tag/v0.21.0-gu2) of french-thrift.

