### PR TITLE
upgrade bridget version after horizontal scroll release in prod

### DIFF
--- a/.changeset/odd-flies-prove.md
+++ b/.changeset/odd-flies-prove.md
@@ -1,0 +1,7 @@
+---
+"bridget": patch
+---
+
+Update bridget version after horizontal scroll release in prod
+
+This version update doesn't have any changes in bridget. The Bridget version 8.1.0 that introduced Interaction service hadn't been fully implemented in the native app. Now the implementation is completed in the android, so we are updating bridget in order to rely on this version in MAPI for articles that need the Interaction service.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Update bridget version after horizontal scroll release in prod

This version update doesn't have any changes in bridget. The Bridget version 8.1.0 that introduced Interaction service hadn't been fully implemented in the native app. Now the implementation is completed in the android, so we are updating bridget in order to rely on this version in MAPI for articles that need the Interaction service.

**TODO:**
After this version is released, we will need to update the min required bridget version in this DCR pull request https://github.com/guardian/android-news-app/pull/10921 to the new bridget version. 

Also, for releasing liveblog to PROD, we would need to use this bridget version in MAPI.
