### PR TITLE
update bridget version without any change

### DIFF
--- a/.changeset/good-emus-jog.md
+++ b/.changeset/good-emus-jog.md
@@ -1,0 +1,7 @@
+---
+"bridget": patch
+---
+
+Update Bridget Version to Set Minimum Requirement for Liveblogs
+
+This version update introduces no changes to Bridget itself. Its sole purpose is to establish a minimum Bridget version requirement for DCAR liveblogs. This is necessary because Android recently fixed an ad-related bug, allowing DCAR liveblogs to be released in production. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bridget",
-  "version": "8.2.0",
+  "version": "8.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bridget",
-      "version": "8.2.0",
+      "version": "8.3.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@changesets/cli": "2.27.11",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Update Bridget Version to Set Minimum Requirement for Liveblogs

This version update introduces no changes to Bridget itself. Its sole purpose is to establish a minimum Bridget version requirement for DCAR liveblogs. This is necessary because Android recently fixed an ad-related bug, allowing DCAR liveblogs to be released in production. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
