### PR TITLE
Add listen to article methods

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -132,10 +132,10 @@ service Notifications {
 }
 
 service ListenToArticle {
-    bool audioExists(1: string articleId)
-    bool playAudio(1: string articleId)
-    bool isPlayingAudio(1: string articleId)
-    bool pauseAudio(1: string articleId)
+    bool isAvailable(1: string articleId)
+    bool play(1: string articleId)
+    bool isPlaying(1: string articleId)
+    bool pause(1: string articleId)
 }
 
 service User {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds the bridget methods the native clients will use in order to be able to display the listen to article button from DCAR. 

Figma file here: 
https://www.figma.com/design/bIOvOoy1lz8b6X3wbDI1Z2/In-article-changes?node-id=219-8421&p=f&t=giyf4wfaHD8Y1bxJ-0

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
