### PR TITLE
Add audio service for listen to audio article

### DIFF
--- a/.changeset/dirty-turkeys-tie.md
+++ b/.changeset/dirty-turkeys-tie.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": minor
+---
+
+Add Audio service

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -138,6 +138,12 @@ service ListenToArticle {
     bool pause(1: string articleId)
 }
 
+service Audio {
+    bool isAvailable()
+    void play()
+    bool isPlaying()
+}
+
 service User {
     bool isPremium(),
     list<string> filterSeenArticles(1:list<string> articleIds),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds the bridget methods the native clients will use for the audio article button from DCAR.

Pre-release: [v0.0.0-2026-03-17](https://github.com/guardian/bridget/releases/tag/v0.0.0-2026-03-17)

Part of https://github.com/guardian/dotcom-rendering/issues/15062
Resolves https://github.com/guardian/dotcom-rendering/issues/15543

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
This has been tested in both ios and android emulators

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
