### PR TITLE
Add MatchNotifications service

### DIFF
--- a/.changeset/eight-fans-jump.md
+++ b/.changeset/eight-fans-jump.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": minor
+---
+
+Add match notification service

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -138,7 +138,6 @@ struct MatchNotificationsAvailability {
 struct FootballTeam {
     1: required string paId; 
     2: required string name; 
-    3: required string tagId;
 }
 
 struct FootballMatch {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -130,6 +130,15 @@ service Notifications {
     bool isFollowing(1:Topic topic),
 }
 
+struct MatchNotificationsAvailability {
+    1: required bool isAvailable;
+    2: optional string unavailableReason;
+}
+
+service MatchNotifications {
+    MatchNotificationsAvailability isAvailable(),
+}
+
 service ListenToArticle {
     bool isAvailable(1: string articleId)
     i32  getAudioDurationSeconds (1: string articleId)

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -136,8 +136,9 @@ struct MatchNotificationsAvailability {
 }
 
 struct FootballTeam {
-    1: required string id; // Team PA id
-    2: required string name; // Team name
+    1: required string paId; 
+    2: required string name; 
+    3: required string tagId;
 }
 
 struct FootballMatch {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -136,7 +136,8 @@ struct MatchNotificationsAvailability {
 }
 
 struct FootballTeam {
-    1: required string id;
+    1: required string id; // Team PA id
+    2: required string name; // Team name
 }
 
 struct FootballMatch {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -135,8 +135,17 @@ struct MatchNotificationsAvailability {
     2: optional string unavailableReason;
 }
 
+struct FootballTeam {
+    1: required string id;
+}
+
+struct FootballMatch {
+    1: required FootballTeam homeTeam;
+    2: required FootballTeam awayTeam;
+}
+
 service MatchNotifications {
-    MatchNotificationsAvailability isAvailable(),
+    MatchNotificationsAvailability isAvailable(1: FootballMatch footballMatch),
 }
 
 service ListenToArticle {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new `MatchNotifications` service. It exposes an isAvailable method that allows the webview to check whether a user should be offered the option to sign up for notifications for a specific football match.

On match info and liveblog pages, we offer the ability to sign up for notifications about that match. However, the native apps also allow users to sign up for notifications about a particular team, which inherently includes the matches they're playing in. Offering the option to sign up for these matches separately to those users results in duplicate notifications.

Currently, the apps solve this problem natively by removing the sign-up button and displaying a message explaining that the user has already signed up for team notifications. This new Bridget API allows the webview to query the app for this state and adjust its UI accordingly to mirror the native experience.

DCR companion PR https://github.com/guardian/dotcom-rendering/pull/15819

Part of https://github.com/guardian/dotcom-rendering/issues/15591