### PR TITLE
Add new media event types

### DIFF
--- a/.changeset/modern-colts-speak.md
+++ b/.changeset/modern-colts-speak.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": patch
+---
+
+Adds new media event types to native thrift

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -67,6 +67,12 @@ enum MediaEvent {
     percent50 = 4,
     percent75 = 5,
     end = 6
+    pause = 7
+    mute = 8
+    unmute = 9
+    enter_fullscreen = 10
+    exit_fullscreen = 11
+    view = 12
 }
 
 struct VideoEvent {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Updates the `MediaEvent` thrift definition to match the new Ophan events. These correspond to tracking events we would like to send for self-hosted video. 