### PR TITLE
Contract for generic live activities

### DIFF
--- a/.changeset/live-activity.md
+++ b/.changeset/live-activity.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": minor
+---
+
+Adding live activity contract to support the implementation of live activities for football matches during the world cup.

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -264,3 +264,16 @@ service Interaction {
 service Interactives {
     NativePlatform getNativePlatform(),
 }
+
+service LiveActivities {
+    /*
+    * for the following methods:
+    * activityType is required and must be "football-match". If this service was extended, this could be a different value.
+    * activityId is an id identifying the activity, depending on the type.
+    *   for "football-match", it is the PA MatchID
+    */
+    bool isAvailable(1: string activityType, 2: string activityId)
+    bool follow(1: string activityType, 2: string activityId)
+    bool unfollow(1: string activityType, 2: string activityId)
+    bool isFollowing(1: string activityType, 2: string activityId)
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This adds a new service for any live activity. This idea is that it can go beyond football matches.

On each of the methods of the new service are two parameters: activityType and activityId.
Activity type can only be "football-match" as of now, but could be extended to "cricket-match" "us-election" etc.
Then activity id is whatever identifies the activity. In the case of a football match it's PA's matchID.

Part of #252.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
