### PR TITLE
Adds video attention time tracking function to videos service

### DIFF
--- a/.changeset/lovely-words-rule.md
+++ b/.changeset/lovely-words-rule.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": minor
+---
+
+Adds video attention time tracking function to videos service

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -186,7 +186,14 @@ service Gallery {
 service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
     void updateVideos(1:list<VideoSlot> videoSlots),
+    /*
+    * This method is used to submit media tracking events for videos from the web layer.
+    * */
     void sendVideoEvent(1:VideoEvent videoEvent),
+    /*
+    * This method is used to submit component attention time tracking updates for videos from the web layer.
+    * */
+    void sendVideoAttentionTime(1:map<string, i64> componentAttentionMs),
     /**
      * This method is used by the web layer to instruct the native layer to activate or deactivate fullscreen mode
      * This is currently only required for Android as the fullscreen control on the YouTube player in Android webviews is a no-op

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -194,7 +194,7 @@ service Videos {
     * This method is used to submit component attention time tracking updates for videos from the web layer.
     * The argument is a map of videoIds to attention milliseconds, matching the native app tracking submission type.
     */
-    void sendVideoAttentionTime(1:map<string, i64> componentAttentionMs),
+    void sendVideoAttentionTimes(1:map<string, i64> componentAttentionMs),
     /**
      * This method is used by the web layer to instruct the native layer to activate or deactivate fullscreen mode
      * This is currently only required for Android as the fullscreen control on the YouTube player in Android webviews is a no-op

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -186,13 +186,14 @@ service Gallery {
 service Videos {
     void insertVideos(1:list<VideoSlot> videoSlots),
     void updateVideos(1:list<VideoSlot> videoSlots),
-    /*
+    /**
     * This method is used to submit media tracking events for videos from the web layer.
-    * */
+    */
     void sendVideoEvent(1:VideoEvent videoEvent),
-    /*
+    /**
     * This method is used to submit component attention time tracking updates for videos from the web layer.
-    * */
+    * The argument is a map of videoIds to attention milliseconds, matching the native app tracking submission type.
+    */
     void sendVideoAttentionTime(1:map<string, i64> componentAttentionMs),
     /**
      * This method is used by the web layer to instruct the native layer to activate or deactivate fullscreen mode


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
As discussed with @abeddow91, @owenmp and @EnochHankombo92. This changes adds a new function the videos service which will allow DCAR video attention time updates to be sent via Bridget to Ophan. This is consistent with the approach take to submit video media events to Ophan via Bridget. 

Related: https://github.com/guardian/dotcom-rendering/blob/ef940ab2214794820992a3a181ce3c2d27340ef4/dotcom-rendering/src/lib/useVideoAttentionTracking.ts#L99-L103

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Not tested, open to suggestions?

