### PR TITLE
Force re-release

### DIFF
--- a/.changeset/re-release.md
+++ b/.changeset/re-release.md
@@ -1,0 +1,5 @@
+---
+"@guardian/bridget": patch
+---
+
+Force github to re-release


### PR DESCRIPTION
Unfortunately I didn't follow the release process, and instead of simply merging to main I had also manually created the release and tag for 8.13.0. Now github fails releasing this version.

This PR is just a way to force it to release 8.13.1