### PR TITLE
Add function to Newsletters service to get logged in users email address

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -255,9 +255,11 @@ service Navigation {
  *  - requestSignUp: request to sign up to a newsletter using an email address entered by the user.
  * Returns `true` if the request was successful, `false` if it failed for any reason. Exceptions
  * thrown will be discarded.
+ * - getLoggedInUserEmail: request currently signed in users email address. Blank if not signed in.
  */
 service Newsletters {
-    bool requestSignUp(1: string emailAddress, 2:string newsletterIdentityName)
+    bool requestSignUp(1: string emailAddress, 2:string newsletterIdentityName),
+    string getLoggedInUserEmail()
 }
 
 service Interaction {


### PR DESCRIPTION
## What does this change?
Adds new method to Newsletters service to get currently logged in user email so that newsletter sign up pages can auto-populate the email input textbox on the page.

## How has this change been tested?
There are Android https://github.com/guardian/android-news-app/pull/13238 and iOS https://github.com/guardian/ios-live/pull/10072 PRs that provide an implementation of this new function by having created a pre-release version of bridget to test this new function. The implementations work when called manually from elsewhere in the code, but this PR needs to be built upon by the newsletters team to prove out the functionality end to end.

WebX Ticket: https://github.com/guardian/bridget/issues/261
AppX Ticket: https://app.asana.com/1/1210045093164357/project/1215309367148854/task/1216357574103304

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216357574103304